### PR TITLE
Fix(excel_io): Legge correttamente le celle unite

### DIFF
--- a/analyzer_app/analysis.py
+++ b/analyzer_app/analysis.py
@@ -105,7 +105,7 @@ def analyze_sheet_data(
     compilation_cells = {
         'analogico': {
             'ODC': (config.KEY_COMP_ANA_ODC_MANCANTE, config.SCHEDA_ANA_CELL_ODC),
-            'DATA': (config.KEY_COMP_ANA_DATA_COMP_MANCANTE, config.SCHEDA_ANA_CELL_DATA_COMPILAZIONE),
+            'CARD_DATE': (config.KEY_COMP_ANA_DATA_COMP_MANCANTE, config.SCHEDA_ANA_CELL_DATA_COMPILAZIONE),
             'PDL': (config.KEY_COMP_ANA_PDL_MANCANTE, config.SCHEDA_ANA_CELL_PDL),
             'ESECUTORE': (config.KEY_COMP_ANA_ESECUTORE_MANCANTE, config.SCHEDA_ANA_CELL_ESECUTORE),
             'SUPERVISORE': (config.KEY_COMP_ANA_SUPERVISORE_MANCANTE, config.SCHEDA_ANA_CELL_SUPERVISORE_ISAB),
@@ -113,7 +113,7 @@ def analyze_sheet_data(
         },
         'digitale': {
             'ODC': (config.KEY_COMP_DIG_ODC_MANCANTE, config.SCHEDA_DIG_CELL_ODC),
-            'DATA': (config.KEY_COMP_DIG_DATA_COMP_MANCANTE, config.SCHEDA_DIG_CELL_DATA_COMPILAZIONE),
+            'CARD_DATE': (config.KEY_COMP_DIG_DATA_COMP_MANCANTE, config.SCHEDA_DIG_CELL_DATA_COMPILAZIONE),
             'PDL': (config.KEY_COMP_DIG_PDL_MANCANTE, config.SCHEDA_DIG_CELL_PDL),
             'ESECUTORE': (config.KEY_COMP_DIG_ESECUTORE_MANCANTE, config.SCHEDA_DIG_CELL_ESECUTORE),
             'SUPERVISORE': (config.KEY_COMP_DIG_SUPERVISORE_MANCANTE, config.SCHEDA_DIG_CELL_SUPERVISORE_ISAB),

--- a/analyzer_app/excel_io.py
+++ b/analyzer_app/excel_io.py
@@ -148,8 +148,19 @@ def read_instrument_sheet_raw_data(file_path: str) -> dict:
             wb = load_workbook(filename=file_path, data_only=True, read_only=True)
             ws = wb.active
             def get_xlsx_value(coord_str):
-                try: return ws[coord_str].value
-                except Exception: return None
+                try:
+                    # Prima controlla se la cella è in un range unito.
+                    # Se lo è, il valore si trova solo nella cella in alto a sinistra del range.
+                    cell = ws[coord_str]
+                    for merged_range in ws.merged_cell_ranges:
+                        if cell.coordinate in merged_range:
+                            # Trovato il range, prendi il valore dalla cella top-left
+                            top_left_cell = ws.cell(row=merged_range.min_row, column=merged_range.min_col)
+                            return top_left_cell.value
+                    # Se non è in nessun range unito, restituisce il valore della cella stessa.
+                    return cell.value
+                except Exception:
+                    return None
             get_value = get_xlsx_value
         except Exception as e:
             raise IOError(f"Errore apertura file .xlsx: {e}") from e
@@ -180,8 +191,8 @@ def read_instrument_sheet_raw_data(file_path: str) -> dict:
             raw_data['odc'] = get_value(config.SCHEDA_DIG_CELL_ODC)
             raw_data['pdl'] = get_value(config.SCHEDA_DIG_CELL_PDL)
             raw_data['esecutore'] = get_value(config.SCHEDA_DIG_CELL_ESECUTORE)
-            raw_data['supervisore_isab'] = get_value(config.SCHEDA_DIG_CELL_SUPERVISORE_ISAB)
-            raw_data['contratto_coemi'] = get_value(config.SCHEDA_DIG_CELL_CONTRATTO_COEMI)
+            raw_data['supervisore'] = get_value(config.SCHEDA_DIG_CELL_SUPERVISORE_ISAB)
+            raw_data['contratto'] = get_value(config.SCHEDA_DIG_CELL_CONTRATTO_COEMI)
             raw_data['cert_ids'] = [get_value(c) for c in ["C18", "E18", "G18"]]
             raw_data['cert_expiries'] = [get_value(c) for c in ["C19", "E19", "G19"]]
             raw_data['cert_models'] = [get_value(c) for c in ["C13", "E13", "G13"]]
@@ -201,8 +212,8 @@ def read_instrument_sheet_raw_data(file_path: str) -> dict:
             raw_data['odc'] = get_value(config.SCHEDA_ANA_CELL_ODC)
             raw_data['pdl'] = get_value(config.SCHEDA_ANA_CELL_PDL)
             raw_data['esecutore'] = get_value(config.SCHEDA_ANA_CELL_ESECUTORE)
-            raw_data['supervisore_isab'] = get_value(config.SCHEDA_ANA_CELL_SUPERVISORE_ISAB)
-            raw_data['contratto_coemi'] = get_value(config.SCHEDA_ANA_CELL_CONTRATTO_COEMI)
+            raw_data['supervisore'] = get_value(config.SCHEDA_ANA_CELL_SUPERVISORE_ISAB)
+            raw_data['contratto'] = get_value(config.SCHEDA_ANA_CELL_CONTRATTO_COEMI)
             raw_data['cert_ids'] = [get_value(c) for c in ["K43", "K44", "K45"]]
             raw_data['cert_expiries'] = [get_value(c) for c in ["M43", "M44", "M45"]]
             raw_data['cert_models'] = [get_value(c) for c in ["A43", "A44", "A45"]]


### PR DESCRIPTION
Risolve un bug per cui l'analisi segnalava un falso positivo per valori mancanti quando la cella target faceva parte di un'area di celle unite in Excel.

La logica di lettura per i file .xlsx in `excel_io.py` è stata aggiornata per verificare se una cella appartiene a un'area unita. In tal caso, il valore viene ora letto correttamente dalla cella in alto a sinistra dell'area.

Inoltre, sono state corrette alcune inconsistenze nei nomi delle chiavi tra `excel_io.py` e `analysis.py` per migliorare la robustezza del codice.
- Rinominato `contratto_coemi` in `contratto`
- Rinominato `supervisore_isab` in `supervisore`
- Aggiornato il controllo della data in `analysis.py` per usare la chiave corretta `CARD_DATE`